### PR TITLE
Mount /deployments folder to allow to persist uber jar files

### DIFF
--- a/pkg/controller/component/dev_deployment.go
+++ b/pkg/controller/component/dev_deployment.go
@@ -70,19 +70,7 @@ func (res deployment) installDev() (runtime.Object, error) {
 				},
 				Spec: corev1.PodSpec{
 					Containers:     []corev1.Container{runtimeContainer},
-					InitContainers: []corev1.Container{
-						supervisorContainer,
-						corev1.Container{
-							Name: "deployments-data-permission-fix",
-							Image: "busybox",
-							Command: []string{
-								"/bin/chown","-R","1001:0", "/deployments",
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{Name: c.Spec.Storage.Name, MountPath: "/deployments"},
-							},
-						},
-					},
+					InitContainers: []corev1.Container{supervisorContainer},
 					Volumes: []corev1.Volume{
 						{Name: "shared-data",
 							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},


### PR DESCRIPTION
Mount /deployments folder to allow to persist uber jar files

fix: Include an initcontainer to change the permissions of the /deployments folder to allow user 1001 to access it 

#141 