### PR TITLE
Pass a new parameter to the Supervisord Program command to autostart run-java

### DIFF
--- a/pkg/controller/component/controller.go
+++ b/pkg/controller/component/controller.go
@@ -65,8 +65,10 @@ func NewComponentReconciler(mgr manager.Manager) *ReconcileComponent {
 			Envs: []v1beta1.NameValuePair{
 				{
 					Name: "CMDS",
-					Value: "run-java:/usr/local/s2i/run;run-node:/usr/libexec/s2i/run;compile-java:/usr/local/s2i" +
-						"/assemble;build:/deployments/buildapp",
+					Value:
+						"run-java:/usr/local/s2i/run:true;" +
+						"run-node:/usr/libexec/s2i/run:false;" +
+						"compile-java:/usr/local/s2i/assemble:false",
 				},
 			},
 		},


### PR DESCRIPTION
feat: Pass a new parameter to the Supervisord Program command in order to autostart the run-java command by default
issue: #144 