### PR TITLE
Issue 185

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,8 +111,8 @@ commands:
       - run:
           name: Install tekton
           command: |
-            TEKTON_VERSION=v0.5.2
-            kubectl apply -f https://storage.googleapis.com/tekton-releases/previous/${TEKTON_VERSION}/release.yaml
+            TEKTON_VERSION=v0.9.1
+            kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/${TEKTON_VERSION}/release.yaml
   install-dekorate-snapshot:
     steps:
       - run:

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ minikube start
 
 Install Tekton Pipelines:
 ```bash
-kubectl apply -f https://storage.googleapis.com/tekton-releases/previous/v0.5.2/release.yaml
+kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.9.1/release.yaml
 ```
 
 Install the `KubeDB` operator and the catalog of the databases using the following bash script as described within the `kubedb` [doc](https://kubedb.com/docs/0.12.0/setup/install/):
@@ -422,7 +422,7 @@ kubectl delete -n operators -f deploy/operator.yaml
 
 ## Compatibility matrix
 
-|                     | Kubernetes >= 1.13 | OpenShift 3.x | OpenShift 4.x | KubeDB 0.12 | Tekton v0.5.x | 
+|                     | Kubernetes >= 1.13 | OpenShift 3.x | OpenShift 4.x | KubeDB 0.12 | Tekton v0.9.x | 
 |---------------------|--------------------|---------------|---------------|-------------|---------------|
 | halkyon v0.1.x      | ✓                  | ✓             | ✓             | ✓           | ✓             |
 

--- a/go.mod
+++ b/go.mod
@@ -24,9 +24,10 @@ require (
 	github.com/rogpeppe/go-internal v1.3.0 // indirect
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/pflag v1.0.3
-	github.com/tektoncd/pipeline v0.3.1
+	github.com/tektoncd/pipeline v0.9.1
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80
 	golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	halkyon.io/api v1.0.0-beta.7
 	k8s.io/api v0.0.0-20190725062911-6607c48751ae
 	k8s.io/apimachinery v0.0.0-20190719140911-bfcf53abc9f8
@@ -36,6 +37,7 @@ require (
 	kmodules.xyz/monitoring-agent-api v0.0.0-20190513065523-186af167f817 // indirect
 	kmodules.xyz/objectstore-api v0.0.0-20190516233206-ea3ba546e348 // indirect
 	kmodules.xyz/offshoot-api v0.0.0-20190527060812-295f97bb8061
+	knative.dev/pkg v0.0.0-20191211150249-bebd5557feae
 	sigs.k8s.io/controller-runtime v0.1.9
 	sigs.k8s.io/controller-tools v0.1.10 // indirect
 	sigs.k8s.io/testing_frameworks v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -377,6 +377,9 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tektoncd/pipeline v0.3.1 h1:LZ0U+HJ3jg3o7e5A7+8nRDEt0G5yJ5seb/uoTxHtBR0=
 github.com/tektoncd/pipeline v0.3.1/go.mod h1:IZzJdiX9EqEMuUcgdnElozdYYRh0/ZRC+NKMLj1K3Yw=
+github.com/tektoncd/pipeline v0.8.0/go.mod h1:IZzJdiX9EqEMuUcgdnElozdYYRh0/ZRC+NKMLj1K3Yw=
+github.com/tektoncd/pipeline v0.9.1 h1:nfhhQKxmo2TeL+LGR5pXlArEaFaRwnw7oAN3F0Gy55U=
+github.com/tektoncd/pipeline v0.9.1/go.mod h1:IZzJdiX9EqEMuUcgdnElozdYYRh0/ZRC+NKMLj1K3Yw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yudai/gojsondiff v0.0.0-20180504020246-0525c875b75c h1:/8Xb/f8s2/ZZpzMzBkFwW2Jvj7Pglk+AW8m8FFqOoIQ=
@@ -476,6 +479,8 @@ golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c h1:97SnQk1GYRXJgvwZ8fadnxDOWfKvkNQHH3CtZntPSrM=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/version v0.0.0-20190507203204-7cec7ee542d3/go.mod h1:Y8xuV02mL/45psyPKG3NCVOwvAOy6T5Kx0l3rCjKSjU=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.4.0 h1:KKgc1aqhV8wDPbDzlDtpvyjZFY3vjz85FP7p4wcQUyI=
@@ -583,6 +588,8 @@ kmodules.xyz/objectstore-api v0.0.0-20190516233206-ea3ba546e348 h1:GViDM6wui0Em6
 kmodules.xyz/objectstore-api v0.0.0-20190516233206-ea3ba546e348/go.mod h1:90TB4uAMAFUHLSbxSl+uAgs/5GIdv5hSAJis4NhC8YU=
 kmodules.xyz/offshoot-api v0.0.0-20190527060812-295f97bb8061 h1:ge49on2TYYdSeYggSHB01u+YFvm89UvcHW278sbp7oM=
 kmodules.xyz/offshoot-api v0.0.0-20190527060812-295f97bb8061/go.mod h1:LT3dsKZJjJIWGGGyzLd6AR3YF5eXDc90B4zC54V3b7Q=
+knative.dev/pkg v0.0.0-20191211150249-bebd5557feae h1:aoXwtJERQEgjDWUAkDda4eurLs6IiWB3baWodGJkMW0=
+knative.dev/pkg v0.0.0-20191211150249-bebd5557feae/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 sigs.k8s.io/controller-runtime v0.1.9 h1:ZcnTZfnCGynyToVwHsqV3bMoGXwViYlnUF8kfMgghK8=
 sigs.k8s.io/controller-runtime v0.1.9/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=
 sigs.k8s.io/controller-tools v0.1.10 h1:onJbaVxkLKbLhy3BcLdesjkP6y+6WFVzg1BJv28BpCo=

--- a/pkg/controller/component/task.go
+++ b/pkg/controller/component/task.go
@@ -65,8 +65,8 @@ func (res task) Build() (runtime.Object, error) {
 						"build",
 					},
 					Args: []string{
-						"${inputs.params.workspacePath}/${inputs.params.contextPath}",
-						"${inputs.params.baseImage}",
+						"$(inputs.params.workspacePath)/$(inputs.params.contextPath)",
+						"$(inputs.params.baseImage)",
 						"--as-dockerfile",
 						"/sources/Dockerfile.gen",
 						"--image-scripts-url",
@@ -74,9 +74,9 @@ func (res task) Build() (runtime.Object, error) {
 						"--loglevel",
 						"5",
 						"--env",
-						"MAVEN_ARGS_APPEND=-pl ${inputs.params.moduleDirName}",
+						"MAVEN_ARGS_APPEND=-pl $(inputs.params.moduleDirName)",
 						"--env",
-						"MAVEN_S2I_ARTIFACT_DIRS=${inputs.params.moduleDirName}/target",
+						"MAVEN_S2I_ARTIFACT_DIRS=$(inputs.params.moduleDirName)/target",
 						"--env",
 						"S2I_SOURCE_DEPLOYMENTS_FILTER=*.jar",
 					},
@@ -96,12 +96,12 @@ func (res task) Build() (runtime.Object, error) {
 					},
 					Args: []string{
 						"bud",
-						"--tls-verify=${inputs.params.verifyTLS}",
+						"--tls-verify=$(inputs.params.verifyTLS)",
 						"--layers",
 						"-f",
 						"/sources/Dockerfile.gen",
 						"-t",
-						"${outputs.resources.image.url}",
+						"$(outputs.resources.image.url)",
 						"."},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -130,9 +130,9 @@ func (res task) Build() (runtime.Object, error) {
 					},
 					Args: []string{
 						"push",
-						"--tls-verify=${inputs.params.verifyTLS}",
-						"${outputs.resources.image.url}",
-						"docker://${outputs.resources.image.url}",
+						"--tls-verify=$(inputs.params.verifyTLS)",
+						"$(outputs.resources.image.url)",
+						"docker://$(outputs.resources.image.url)",
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/controller/component/taskrun.go
+++ b/pkg/controller/component/taskrun.go
@@ -2,12 +2,12 @@ package component
 
 import (
 	"fmt"
-	"github.com/knative/pkg/apis"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"halkyon.io/api/component/v1beta1"
 	"halkyon.io/operator/pkg/controller/framework"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
 )
 
 type taskRun struct {
@@ -33,7 +33,8 @@ func (res taskRun) Build() (runtime.Object, error) {
 			Labels:    ls,
 		},
 		Spec: v1alpha1.TaskRunSpec{
-			ServiceAccount: ServiceAccountName(c),
+			//ServiceAccountName: ServiceAccountName(c),
+			ServiceAccountName: "build-bot",
 			TaskRef: &v1alpha1.TaskRef{
 				Name: TaskName(c),
 			},
@@ -41,36 +42,35 @@ func (res taskRun) Build() (runtime.Object, error) {
 				Params: []v1alpha1.Param{
 					// See description of the parameters within the Tasks
 					// We only override parameters here. Defaults are defined within the Tasks
-					{Name: "baseImage", Value: baseImage(c)},
-					{Name: "moduleDirName", Value: moduleDirName(c)},
-					{Name: "contextPath", Value: contextPath(c)},
+					{Name: "baseImage", Value: v1alpha1.ArrayOrString{Type: v1alpha1.ParamTypeString, StringVal: baseImage(c)}},
+					{Name: "moduleDirName", Value: v1alpha1.ArrayOrString{Type: v1alpha1.ParamTypeString, StringVal: moduleDirName(c)}},
+					{Name: "contextPath", Value: v1alpha1.ArrayOrString{Type: v1alpha1.ParamTypeString, StringVal: contextPath(c)}},
 				},
-				Resources: []v1alpha1.TaskResourceBinding{
-					{
+				Resources: []v1alpha1.TaskResourceBinding{{
+					PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
 						Name: "git",
 						ResourceSpec: &v1alpha1.PipelineResourceSpec{
 							Type: "git",
-							Params: []v1alpha1.Param{
+							Params: []v1alpha1.ResourceParam{
 								{
 									Name:  "revision",
 									Value: gitRevision(c),
 								},
 								{
 									Name:  "url",
-									Value: c.Spec.BuildConfig.URL,
-								},
+									Value: c.Spec.BuildConfig.URL},
 							},
 						},
 					},
-				},
+				}},
 			},
 			Outputs: v1alpha1.TaskRunOutputs{
-				Resources: []v1alpha1.TaskResourceBinding{
-					{
+				Resources: []v1alpha1.TaskResourceBinding{{
+					PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
 						Name: "image",
 						ResourceSpec: &v1alpha1.PipelineResourceSpec{
 							Type: "image",
-							Params: []v1alpha1.Param{
+							Params: []v1alpha1.ResourceParam{
 								{
 									Name: "url",
 									// Calculate the path of the image using docker registry URL for ocp or k8s cluster
@@ -79,7 +79,7 @@ func (res taskRun) Build() (runtime.Object, error) {
 							},
 						},
 					},
-				},
+				}},
 			},
 		},
 	}

--- a/pkg/controller/component/taskrun.go
+++ b/pkg/controller/component/taskrun.go
@@ -33,8 +33,7 @@ func (res taskRun) Build() (runtime.Object, error) {
 			Labels:    ls,
 		},
 		Spec: v1alpha1.TaskRunSpec{
-			//ServiceAccountName: ServiceAccountName(c),
-			ServiceAccountName: "build-bot",
+			ServiceAccountName: ServiceAccountName(c),
 			TaskRef: &v1alpha1.TaskRef{
 				Name: TaskName(c),
 			},


### PR DESCRIPTION
- Bump Tekton version to `v0.9.1`
- Update README doc
- Fully tested using end to end script on ocp-311 cluster 
- Replace `${}` to `$()` due to API change